### PR TITLE
feat: add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:3
+
+RUN dpkg --add-architecture i386 && apt update && apt install libc6-i386

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "build": { "dockerfile": "Dockerfile" }
+}


### PR DESCRIPTION
Adds a VSCode [Development Container](https://code.visualstudio.com/docs/remote/create-dev-container) to run an isolated Docker container with the required i386 build environment dependencies