### PR TITLE
use Git version

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -2,8 +2,9 @@
 
 APP_PATH=$1
 APP_NAME=$2
-APP_VERSION=$3
-USER_CMD=$4
+//APP_VERSION=$3
+APP_VERSION="`(cd apps/OpenBK* && git describe --abbrev=8 --always)`"
+USER_CMD=$3
 echo APP_PATH=$APP_PATH
 echo APP_NAME=$APP_NAME
 echo APP_VERSION=$APP_VERSION


### PR DESCRIPTION
This change goes together with the pull request in the new_http.c for the https://github.com/openshwprojects/OpenBK7231T_App/ repository.
This sets the version to be the Git version, easier to recall and automatically increased.