### PR TITLE
use Git version if 'git' or no version is given

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -4,6 +4,10 @@ APP_PATH=$1
 APP_NAME=$2
 APP_VERSION=$3
 USER_CMD=$4
+
+[ "$APP_VERSION" = "git" ] && APP_VERSION="`(cd apps/OpenBK* && git describe --abbrev=8 --always)`"
+[ -z "$APP_VERSION" ] && [ -z $USER_CMD ] && APP_VERSION="`(cd apps/OpenBK* && git describe --abbrev=8 --always)`"
+
 echo APP_PATH=$APP_PATH
 echo APP_NAME=$APP_NAME
 echo APP_VERSION=$APP_VERSION


### PR DESCRIPTION
When build_app.sh is called with a third argument it will be the version, unless that third argument is 'git'
When no third argument is given or the third argument is 'git' it will retrieve the git version.
This change goes together with the pull request in the new_http.c for the https://github.com/openshwprojects/OpenBK7231T_App/ repository.
This shows the version in the webpages, easier to recall and automatically increased.