### PR TITLE
omit git binary, use app_path variable, more error info

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -1,12 +1,21 @@
 #!/bin/sh
+fatal() {
+    echo -e "\033[0;31merror: $1\033[0m"
+    exit 1
+}
+
+
 
 APP_PATH=$1
 APP_NAME=$2
 APP_VERSION=$3
 USER_CMD=$4
 
-[ "$APP_VERSION" = "git" ] && APP_VERSION="`(cd apps/OpenBK* && git describe --abbrev=8 --always)`"
-[ -z "$APP_VERSION" ] && [ -z $USER_CMD ] && APP_VERSION="`(cd apps/OpenBK* && git describe --abbrev=8 --always)`"
+[ -z $APP_PATH ] && fatal "no app path!"
+[ -z $APP_NAME ] && fatal "no app name!"
+
+[ "$APP_VERSION" = "git" ] && APP_VERSION="`(head -c8 $APP_PATH/.git/refs/heads/main)`"
+[ -z "$APP_VERSION" ] && [ -z $USER_CMD ] && APP_VERSION="`(head -c8 $APP_PATH/.git/refs/heads/main)`"
 
 if [ -z "${APP_VERSION}" ]; then 
 	echo "App version not specified (or git command failed on Cygwin), using 1.0.0"
@@ -19,14 +28,6 @@ echo APP_VERSION=$APP_VERSION
 echo USER_CMD=$USER_CMD
 
 
-fatal() {
-    echo -e "\033[0;31merror: $1\033[0m"
-    exit 1
-}
-
-
-[ -z $APP_PATH ] && fatal "no app path!"
-[ -z $APP_NAME ] && fatal "no app name!"
 [ -z $APP_VERSION ] && fatal "no version!"
 
 

--- a/build_app.sh
+++ b/build_app.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 fatal() {
-    echo -e "\033[0;31merror: $1\033[0m"
+    echo "\033[0;31merror: $1\033[0m"
+    echo
+    echo "Usage: $0 app_path app_name [app_version [user_cmd]]"
+    echo "see https://github.com/openshwprojects/OpenBK7231T_App/ for full info"
     exit 1
 }
 


### PR DESCRIPTION
I'm currently not able to build due to another error, but this script seems to work as intended
```
:~/tuya/OpenBK7231T$ ./build_app.sh apps/OpenBK7231T_App/ OpenBK7231Tapp
APP_PATH=apps/OpenBK7231T_App/
APP_NAME=OpenBK7231Tapp
APP_VERSION=32ebba46
USER_CMD=

:~/tuya/OpenBK7231T$ ./build_app.sh apps/OpenBK7231T_App/ OpenBK7231Tapp git
APP_PATH=apps/OpenBK7231T_App/
APP_NAME=OpenBK7231Tapp
APP_VERSION=32ebba46
USER_CMD=

:~/tuya/OpenBK7231T$ ./build_app.sh apps/OpenBK7231T_App/ OpenBK7231Tapp gitg
APP_PATH=apps/OpenBK7231T_App/
APP_NAME=OpenBK7231Tapp
APP_VERSION=gitg
USER_CMD=

:~/tuya/OpenBK7231T$ ./build_app.sh apps/OpenBK7231T_App/ OpenBK7231Tapp 1.0.0.0 debug
APP_PATH=apps/OpenBK7231T_App/
APP_NAME=OpenBK7231Tapp
APP_VERSION=1.0.0.0
USER_CMD=debug
````


the error on my compile train:
```
Debug/obj/app_bk.o: In function `init_app_thread':
/home/me/tuya/OpenBK7231T/platforms/bk7231t/bk7231t_os/beken378/app/app_bk.c:717: undefined reference to `user_main'
collect2: error: ld returned 1 exit status
```