### PR TITLE
Add power save metrics - 

### DIFF
--- a/platforms/bk7231t/bk7231t_os/beken378/func/power_save/mcu_ps.h
+++ b/platforms/bk7231t/bk7231t_os/beken378/func/power_save/mcu_ps.h
@@ -30,5 +30,24 @@ typedef struct
     UINT32 machw_tm;
 } MCU_PS_MACHW_TM;
 
+#define OBK_MCU_SLEEP_METRICS_ENABLE 1
+#ifdef OBK_MCU_SLEEP_METRICS_ENABLE
+typedef struct
+{
+    UINT32 sleep_requested_ticks;
+    UINT32 slept_ticks;
+    UINT32 longest_sleep_1s;
+    UINT32 longest_sleep;
+    UINT32 longest_sleep_req_1s;
+    UINT32 longest_sleep_req;
+
+    UINT32 reasons[10];
+    
+
+    char *nexttask;
+    char *task;
+} OBK_MCU_SLEEP_METRICS;
+#endif
+
 #endif
 

--- a/platforms/bk7231t/bk7231t_os/beken378/os/FreeRTOSv9.0.0/FreeRTOS/Source/tasks.c
+++ b/platforms/bk7231t/bk7231t_os/beken378/os/FreeRTOSv9.0.0/FreeRTOS/Source/tasks.c
@@ -4853,5 +4853,18 @@ BaseType_t xTaskIsTaskFinished( xTaskHandle xTask )
 	
     return pdTRUE;
 }
+
+
+static char *none = "none";
+char *OBK_GetNextTaskName(){
+	TCB_t *pxTCB = ( TCB_t * ) listGET_OWNER_OF_HEAD_ENTRY( pxDelayedTaskList );
+	if (pxTCB){
+		return pxTCB->pcTaskName;
+	} else {
+		return none;
+	}
+}
+
+
 // eof
 


### PR DESCRIPTION
a structure we can read to see how much we slept.

defines
#ifdef OBK_MCU_SLEEP_METRICS_ENABLE
in mcu_ps.h

if defined, then the structure
OBK_MCU_SLEEP_METRICS OBK_Mcu_metrics = {0};

will contain:
typedef struct
{
    UINT32 sleep_requested_ticks; // how many ticks of sleep have been requested
    UINT32 slept_ticks; // how many ticks we actually slept for
    UINT32 longest_sleep_1s; // longest individual sleep
    UINT32 longest_sleep; // longest individual sleep
    UINT32 longest_sleep_req_1s; // longest individual sleep requested
    UINT32 longest_sleep_req; // longest individual sleep requested

    UINT32 reasons[10]; // counts of reasons we did NOT sleep
    

    char *nexttask; // the next task if we slept
    char *task; // the next task whether we slept or not.
} OBK_MCU_SLEEP_METRICS;

where slept_ticks tells us how long we have slept for.
