### PR TITLE
Array index in the loop greather than possible arry size - fixed.

### DIFF
--- a/platforms/bk7231t/bk7231t_os/beken378/func/power_save/manual_ps.c
+++ b/platforms/bk7231t/bk7231t_os/beken378/func/power_save/manual_ps.c
@@ -41,7 +41,7 @@ void power_save_wakeup_with_peri( UINT8 uart2_wk, UINT32 gpio_index_map)
 	//UINT32 ret;
     UINT32 param = 0;
     UINT32 i;
-    UINT32    gpio_stat_cfg[32];
+    UINT32    gpio_stat_cfg[GPIONUM];
 
     if(power_save_ps_mode_get() != PS_NO_PS_MODE)
     {


### PR DESCRIPTION
It looks that in file manual_ps.c in function power_save_wakeup_with_peri() there was a bug with iteration index greater than iterated array maximum size.

During loop iteration maximum iteration index was 40 (GPIONUM) but declared size of gpio_stat_cfg[] array was 32. That was also the root cause of the below warnings.

![fix](https://github.com/openshwprojects/OpenBK7231T/assets/157368639/8493d7bd-a5c7-4c1a-b6ac-e343662934c8)
