### PR TITLE
Fix build in gh actions & reduce binary size

### DIFF
--- a/platforms/bk7231t/bk7231t_os/application.mk
+++ b/platforms/bk7231t/bk7231t_os/application.mk
@@ -234,28 +234,28 @@ SRC_C += ./beken378/driver/sys_ctrl/sys_ctrl.c
 SRC_C += ./beken378/driver/uart/Retarget.c
 SRC_C += ./beken378/driver/uart/uart_bk.c
 SRC_C += ./beken378/driver/wdt/wdt.c
-SRC_C += ./beken378/driver/ble/ble.c
-SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/hl/src/prf/prf.c
-SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/sdp/src/sdp_service.c
-SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/sdp/src/sdp_service_task.c
-SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/comm/src/comm.c
-SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/comm/src/comm_task.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_ble.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_task.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_sdp.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_sec.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_comm.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/common/src/common_list.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/common/src/common_utils.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/common/src/RomCallFlash.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg_mwsgen.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg_swdiag.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg_task.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/rwip/src/rwip.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/rf/src/ble_rf_xvr.c
-SRC_C += ./beken378/driver/ble/ble_pub/modules/ecc_p256/src/ecc_p256.c
-SRC_C += ./beken378/driver/ble/ble_pub/plf/refip/src/driver/uart/uart.c           
+#SRC_C += ./beken378/driver/ble/ble.c
+#SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/hl/src/prf/prf.c
+#SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/sdp/src/sdp_service.c
+#SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/sdp/src/sdp_service_task.c
+#SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/comm/src/comm.c
+#SRC_C += ./beken378/driver/ble/ble_pub/ip/ble/profiles/comm/src/comm_task.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_ble.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_task.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_sdp.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_sec.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/app/src/app_comm.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/common/src/common_list.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/common/src/common_utils.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/common/src/RomCallFlash.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg_mwsgen.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg_swdiag.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/dbg/src/dbg_task.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/rwip/src/rwip.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/rf/src/ble_rf_xvr.c
+#SRC_C += ./beken378/driver/ble/ble_pub/modules/ecc_p256/src/ecc_p256.c
+#SRC_C += ./beken378/driver/ble/ble_pub/plf/refip/src/driver/uart/uart.c           
 
 #function layer
 SRC_C += ./beken378/func/func.c
@@ -665,7 +665,7 @@ CPPDEFINES += -DPLATFORM_BK7231T=1
 CPPDEFINES += -DPLATFORM_BEKEN=1
 
 CCFLAGS = $(CPPDEFINES)
-CCFLAGS += -g -mthumb -mcpu=arm968e-s -march=armv5te -mthumb-interwork -mlittle-endian -Os
+CCFLAGS += -g0 -mthumb -mcpu=arm968e-s -march=armv5te -mthumb-interwork -mlittle-endian -Os
 CCFLAGS += -ffunction-sections -fsigned-char -fdata-sections -Wno-unused-function -Wno-unused-but-set-variable
 
 CXXFLAGS = $(CCFLAGS)
@@ -674,14 +674,14 @@ CXXFLAGS += -std=gnu++11 -MMD -fno-exceptions -fno-rtti -Wno-literal-suffix -Wno
 CFLAGS = $(CCFLAGS)
 CFLAGS += -std=c99 -Wunknown-pragmas -nostdlib -Wall
 
-OSFLAGS =
-OSFLAGS += -g -marm -mcpu=arm968e-s -march=armv5te -mthumb-interwork -mlittle-endian -Os -std=c99 -ffunction-sections -Wall -fsigned-char -fdata-sections -Wunknown-pragmas
+OSFLAGS = -flto
+OSFLAGS += -g0 -marm -mcpu=arm968e-s -march=armv5te -mthumb-interwork -mlittle-endian -Os -std=c99 -ffunction-sections -Wall -fsigned-char -fdata-sections -Wunknown-pragmas
 
 ASMFLAGS = 
-ASMFLAGS += -g -marm -mthumb-interwork -mcpu=arm968e-s -march=armv5te -x assembler-with-cpp
+ASMFLAGS += -g0 -marm -mthumb-interwork -mcpu=arm968e-s -march=armv5te -x assembler-with-cpp
 
-LFLAGS = 
-LFLAGS += -g -Wl,--gc-sections -marm -mcpu=arm968e-s -mthumb-interwork 
+LFLAGS = -flto
+LFLAGS += -g0 -Wl,--gc-sections -marm -mcpu=arm968e-s -mthumb-interwork 
 # LFLAGS += -nostdlib
 LFLAGS += -Xlinker -Map=tuya.map  
 LFLAGS += -Wl,-wrap,malloc -Wl,-wrap,_malloc_r -Wl,-wrap,free -Wl,-wrap,_free_r -Wl,-wrap,zalloc -Wl,-wrap,calloc -Wl,-wrap,realloc  -Wl,-wrap,_realloc_r

--- a/platforms/bk7231t/bk7231t_os/beken378/app/config/sys_config.h
+++ b/platforms/bk7231t/bk7231t_os/beken378/app/config/sys_config.h
@@ -111,7 +111,7 @@
 #define CFG_USE_CAMERA_INTF                        0
 
 /*section 13-----for GENERRAL DMA */
-#define CFG_GENERAL_DMA                            0
+#define CFG_GENERAL_DMA                            1
 
 /*section 14-----for FTPD UPGRADE*/
 #define CFG_USE_FTPD_UPGRADE                       0
@@ -146,7 +146,7 @@
 #define CFG_SYS_REDUCE_NORMAL_POWER                0
 
 /*section 24 ----- less memery in rwnx*/
-#define CFG_LESS_MEMERY_IN_RWNX                    0
+#define CFG_LESS_MEMERY_IN_RWNX                    1
 
 /*section 25 ----- use audio*/
 #define CFG_USE_AUDIO                              0
@@ -160,8 +160,8 @@
 #define CFG_USE_TUYA_CCA_TEST                      0
 
 #define CFG_AP_MONITOR_COEXIST                     1
-#define CFG_SUPPORT_BLE                            1
-#define CFG_USE_BLE_PS                             1
+#define CFG_SUPPORT_BLE                            0
+#define CFG_USE_BLE_PS                             0
 
 #define CFG_ENABLE_ATE_FEATURE                     0
 #define CFG_RWNX_QOS_MSDU						   1

--- a/platforms/bk7231t/bk7231t_os/beken378/driver/common/dd.c
+++ b/platforms/bk7231t/bk7231t_os/beken378/driver/common/dd.c
@@ -117,7 +117,7 @@ static DD_INIT_S dd_init_tbl[] =
     {"power_save",       sctrl_sta_ps_init,                NULLPTR},
 #endif
 
-#ifdef CFG_SUPPORT_BLE
+#if CFG_SUPPORT_BLE
 	{BLE_DEV_NAME,			ble_init,					ble_exit}, //sean
 #endif
 

--- a/platforms/bk7231t/bk7231t_os/beken378/os/platform_stub.c
+++ b/platforms/bk7231t/bk7231t_os/beken378/os/platform_stub.c
@@ -79,5 +79,33 @@ void __assert_func(const char *file, int line, const char *func, const char *fai
 	ASSERT(0);
 }
 
+void __attribute__((weak)) rwip_wakeup(void) {}
+void __attribute__((weak)) rwip_wakeup_end(void) {}
+uint8_t __attribute__((weak)) ble_switch_mac_sleeped = 0;
+uint8_t __attribute__((weak)) ble_active = 0;
+void __attribute__((weak)) ble_switch_rf_to_wifi(void) {}
+uint8_t __attribute__((weak)) ble_is_start(void)
+{
+	return 0;
+}
+uint32_t __attribute__((weak)) ble_in_dut_mode(void)
+{
+	return 0;
+}
+uint8 __attribute__((weak)) is_rf_switch_to_ble(void)
+{
+	return 0;
+}
+uint32_t ea_time_get_halfslot_rounded(void);
+uint32_t ea_timer_next_target_get(void);
+uint32_t __attribute__((weak)) rwip_get_current_time(void)
+{
+	return (ea_time_get_halfslot_rounded());
+}
+uint32_t __attribute__((weak)) rwip_get_next_target_time(void)
+{
+	return (ea_timer_next_target_get());
+}
+
 // eof
 

--- a/platforms/bk7231t/bk7231t_os/build.sh
+++ b/platforms/bk7231t/bk7231t_os/build.sh
@@ -76,9 +76,9 @@ make APP_BIN_NAME=$APP_BIN_NAME USER_SW_VER=$USER_SW_VER APP_VERSION=$APP_VERSIO
 echo "Start Combined"
 cp ${APP_PATH}/$APP_BIN_NAME/output/$APP_VERSION/${APP_BIN_NAME}_${APP_VERSION}.bin tools/generate/
 echo "Combined will do cd"
-cd tools/generate
+cd tools/generate/
 echo "Combined will do OTAFIX"
-./${OTAFIX} ${APP_BIN_NAME}_${APP_VERSION}.bin
+./${OTAFIX} ${APP_BIN_NAME}_${APP_VERSION}.bin &
 echo "Combined will do ENCRYPT"
 ./${ENCRYPT} ${APP_BIN_NAME}_${APP_VERSION}.bin 510fb093 a3cbeadc 5993a17e c7adeb03 10000
 echo "Combined will do mpytools.py"


### PR DESCRIPTION
Also:
- Disabled bluetooth
- Used LTO for os (this reduced rbl by 1-2kb in new sdk)
- Enabled CFG_LESS_MEMERY_IN_RWNX (should increase available stack)
- Enabled CFG_GENERAL_DMA (needed for ws2812?)
- Use g0 flag instead of g for gcc